### PR TITLE
Fix spelling on home page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,7 +15,7 @@ const Home: NextPage = () => {
 				<ul className={styles.home__list}>
 					<li className={styles.home__listitem}>
 						<a className={styles.home__link} href="https://www.linkedin.com/in/joeribreedveld/" target="_blank" rel="noreferrer">
-							Linkedin
+							LinkedIn
 						</a>
 					</li>
 					<li className={styles.home__listitem}>


### PR DESCRIPTION
This pull request is for the spelling fixed in the home page.

To achieve this, I had to:
- Change Linkedin to LinkedIn